### PR TITLE
Share `HttpException` from the app with the extensions-lib

### DIFF
--- a/library/src/main/java/eu/kanade/tachiyomi/network/OkHttpExtensions.kt
+++ b/library/src/main/java/eu/kanade/tachiyomi/network/OkHttpExtensions.kt
@@ -9,3 +9,12 @@ fun Call.asObservable(): Observable<Response> = throw Exception("Stub!")
 fun Call.asObservableSuccess(): Observable<Response> = throw Exception("Stub!")
 
 suspend fun Call.await(): Response = throw Exception("Stub!")
+
+/**
+ * Exception that handles HTTP codes considered not successful by OkHttp.
+ * Use it to have a standardized error message in the app across the extensions.
+ *
+ * @since extensions-lib 1.5
+ * @param code [Int] the HTTP status code
+ */
+class HttpException(val code: Int) : IllegalStateException("HTTP error $code")


### PR DESCRIPTION
Will allow standardizing the error message in the future if extensions needs to use it instead of manually creating exceptions with the same message.

Not really sure if this is the right way to add it as a stub, so if the code is wrong, just let me know.